### PR TITLE
Fix/various

### DIFF
--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   php-syntax-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -5,9 +5,6 @@ on:
 
 jobs:
   php-syntax-check:
-    permissions:
-      pull-requests: write
-      contents: read
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Check PHP files
         run: |
           echo "Checking for PHP syntax errors.."
+          ok=true
           for f in $(git ls-files '*.php')
           do
             php -l $f || ok=false


### PR DESCRIPTION
## Description

Fixes following initial comments, as below
- Fix/downgrade permissions requested
- Improve final output of 'ok' status

Note:
- Trying to upgrade to ubuntu-24.04 results in:
`Skipping unsupported platform -- Try running with -P ubuntu-24.04=...`

Comments:
"
https://github.com/dxw/govpress-workflow-php-syntax-check/blob/d640d94ce8d4ab786c3c5b9c4f1b2a2f4fffd368/.github/workflows/php-syntax-check.yml#L9 - I don't think you should need pull-requests permissions here (or certainly not write ones). The Whippet workflow only has that because it writes comments to the PRs
https://github.com/dxw/govpress-workflow-php-syntax-check/blob/d640d94ce8d4ab786c3c5b9c4f1b2a2f4fffd368/.github/workflows/php-syntax-check.yml#L11 - the ubuntu-20.04 image is being decommissioned, you probably want ubuntu-24.04 here
https://github.com/dxw/govpress-workflow-php-syntax-check/blob/d640d94ce8d4ab786c3c5b9c4f1b2a2f4fffd368/.github/workflows/php-syntax-check.yml#L25 This echos an empty string for $ok if everything passes, is that intentional?
"